### PR TITLE
Update build.sh and readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ See [Releases](https://github.com/davidbailey00/deezer-deb-builder/releases)
 4. Download the latest Deezer Windows or macOS installer, as `deezer.exe` or `deezer.dmg` respectively, e.g. using wget:
 
    ```sh
-   wget 'https://e-cdn-content.dzcdn.net/builds/deezer-desktop/8cF2rAuKxLcU1oMDmCYm8Uiqe19Ql0HTySLssdzLkQ9ZWHuDTp2JBtQOvdrFzWPA/darwin/x64/4.18.30/DeezerDesktop_4.18.30.dmg' -O deezer.dmg
+   wget https://e-cdn-content.dzcdn.net/builds/deezer-desktop/8cF2rAuKxLcU1oMDmCYm8Uiqe19Ql0HTySLssdzLkQ9ZWHuDTp2JBtQOvdrFzWPA/darwin/x64/4.20.0/DeezerDesktop_4.20.0.dmg' -O deezer.dmg
    ```
 
 # Build

--- a/README.md
+++ b/README.md
@@ -36,8 +36,16 @@ See [Releases](https://github.com/davidbailey00/deezer-deb-builder/releases)
 
 4. Download the latest Deezer Windows or macOS installer, as `deezer.exe` or `deezer.dmg` respectively, e.g. using wget:
 
+   MacOS
    ```sh
    wget https://e-cdn-content.dzcdn.net/builds/deezer-desktop/8cF2rAuKxLcU1oMDmCYm8Uiqe19Ql0HTySLssdzLkQ9ZWHuDTp2JBtQOvdrFzWPA/darwin/x64/4.20.0/DeezerDesktop_4.20.0.dmg' -O deezer.dmg
+   ```
+
+   or
+
+   Windows
+   ```sh 
+   wget https://e-cdn-content.dzcdn.net/builds/deezer-desktop/8cF2rAuKxLcU1oMDmCYm8Uiqe19Ql0HTySLssdzLkQ9ZWHuDTp2JBtQOvdrFzWPA/win32/x86/4.19.20/DeezerDesktopSetup_4.19.20.exe -O deezer.exe
    ```
 
 # Build

--- a/build.sh
+++ b/build.sh
@@ -2,7 +2,7 @@
 set -e
 
 ELECTRON_VERSION=6.1.7
-DEEZER_VERSION=4.18.50
+DEEZER_VERSION=4.20.0
 DEEZER_BINARY=deezer.exe
 DEEZER_DMG=deezer.dmg
 
@@ -105,11 +105,12 @@ fi
 # Convert Deezer.icns to PNG
 if ! [ -f build/app/Deezer_512x512x32.png ]; then
   macos_icon="build/deezer/Deezer $DEEZER_VERSION/Deezer.app/Contents/Resources/Deezer.icns"
-  if [ -f "$macos_icon" ]; then
-    icns2png -x -s 512x512 "$macos_icon" -o build/app
-  else
+  #if [ -f "$macos_icon" ]; then
+    # Can't find 512x512 only 128x128
+    #icns2png -x -s 512x512 "$macos_icon" -o build/app
+  #else
     cp Deezer_512x512x32.png build/app
-  fi
+  #fi
 fi
 
 # Create Electron distribution


### PR DESCRIPTION
For some reason mac version v4.20.0 does not have 512x512 icon - so i removed the line for that in build.sh

Updated readme to include download URL for latest mac and windows packages. 